### PR TITLE
Add ability to update 'user' field of SASL XOAUTH2 authentication

### DIFF
--- a/front/authorization.form.php
+++ b/front/authorization.form.php
@@ -27,12 +27,30 @@
 include ('../../../inc/includes.php');
 
 $authorization = new PluginOauthimapAuthorization();
+$application   = new PluginOauthimapApplication();
 
 if (isset($_POST['id']) && isset($_POST['delete'])) {
    $authorization->check($_POST['id'], DELETE);
    $authorization->delete($_POST);
 
    Html::back();
-}
+} else if (isset($_POST['id']) && isset($_POST['update'])) {
+   $authorization->check($_POST['id'], UPDATE);
+   if ($authorization->update($_POST)
+      && $application->getFromDB($authorization->fields[$application->getForeignKeyField()])) {
+      Html::redirect($application->getLinkURL());
+   }
 
-Html::displayErrorAndDie('lost');
+   Html::back();
+} else if (isset($_GET['id'])) {
+   $application = new PluginOauthimapApplication();
+   $application->displayHeader();
+   $authorization->display(
+      [
+         'id' => $_GET['id'],
+      ]
+   );
+   Html::footer();
+} else {
+   Html::displayErrorAndDie('lost');
+}

--- a/inc/authorization.class.php
+++ b/inc/authorization.class.php
@@ -34,6 +34,9 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class PluginOauthimapAuthorization extends CommonDBChild {
 
+   // From CommonGlpi
+   protected $displaylist  = false;
+
    // From CommonDBTM
    public $dohistory       = true;
 
@@ -100,7 +103,7 @@ class PluginOauthimapAuthorization extends CommonDBChild {
          echo '<tr><th>' . __('No authorizations.', 'oauthimap') . '</th></tr>';
       } else {
          echo '<tr>';
-         echo '<th>' . __('Email') . '</th>';
+         echo '<th>' . __('Email', 'oauthimap') . '</th>';
          echo '<th></th>';
          echo '</tr>';
 
@@ -110,7 +113,11 @@ class PluginOauthimapAuthorization extends CommonDBChild {
             echo '<td>' . $row['email'] . '</td>';
 
             echo '<td>';
-            echo '<form method="POST" action="' . Plugin::getWebDir('oauthimap') . '/front/authorization.form.php">';
+            echo '<a class="vsubmit" href="' . self::getFormURLWithID($row['id']) . '">';
+            echo __('Update', 'oauthimap');
+            echo '</a>';
+            echo ' ';
+            echo '<form method="POST" action="' . self::getFormURL() . '" style="display:inline-block;">';
             echo Html::hidden('_glpi_csrf_token', ['value' => Session::getNewCSRFToken()]);
             echo Html::hidden('id', ['value' => $row['id']]);
             echo '<button type="submit" class="vsubmit" name="delete" value="1">';
@@ -125,6 +132,38 @@ class PluginOauthimapAuthorization extends CommonDBChild {
       }
       echo '</table>';
       echo '</div>';
+
+      return true;
+   }
+
+   public function showForm($id, $options = []) {
+
+      $options['colspan'] = 1;
+
+      $this->initForm($id, $options);
+      $this->showFormHeader($options);
+
+      echo '<tr class="tab_bg_1">';
+      echo '<td>';
+      echo __('Email', 'oauthimap');
+      echo ' ';
+      echo Html::showToolTip(
+         __('This email address corresponds to the "user" field of the SASL XOAUTH2 authentication query.'),
+         ['display' => false]
+      );
+      echo '</td>';
+      echo '<td>';
+      echo Html::input(
+         'email',
+         [
+            'value' => $this->fields['email'],
+            'style' => 'width:90%'
+         ]
+      );
+      echo '</td>';
+      echo '</tr>';
+
+      $this->showFormButtons($options + ['candel' => false]);
 
       return true;
    }
@@ -292,6 +331,10 @@ class PluginOauthimapAuthorization extends CommonDBChild {
       return $this->owner_details;
    }
 
+   function post_updateItem($history = 1) {
+      MailCollectorFeature::postUpdateAuthorization($this);
+      parent::post_updateItem($history);
+   }
 
    function post_purgeItem() {
       MailCollectorFeature::postPurgeAuthorization($this);

--- a/inc/mailcollectorfeature.class.php
+++ b/inc/mailcollectorfeature.class.php
@@ -337,6 +337,37 @@ JAVASCRIPT;
    }
 
    /**
+    * Update mail collectors linked to the authorization.
+    *
+    * @param PluginOauthimapAuthorization $authorization
+    *
+    * @return void
+    */
+   public static function postUpdateAuthorization(PluginOauthimapAuthorization $authorization): void {
+      if (in_array('email', $authorization->updates) && array_key_exists('email', $authorization->oldvalues)) {
+         $collectors = self::getAssociatedMailCollectors(
+            self::getMailProtocolTypeIdentifier($authorization->fields[PluginOauthimapApplication::getForeignKeyField()]),
+            $authorization->oldvalues['email']
+         );
+         foreach ($collectors as $row) {
+            $mailcollector = new MailCollector();
+            $mailcollector->update(
+               [
+                  'id'    => $row['id'],
+                  'login' => $authorization->fields['email'],
+               ]
+            );
+            Session::addMessageAfterRedirect(
+               sprintf(
+                  __('Mail receiver "%s" has been updated.', 'oauthimap'),
+                  $mailcollector->getName()
+               )
+            );
+         }
+      }
+   }
+
+   /**
     * Deactivate mail collectors using given protocol type and given login.
     *
     * @param string $protocol_type


### PR DESCRIPTION
This will give ability to use shared mailboxes on Azure (see https://github.com/MicrosoftDocs/office-developer-exchange-docs/blob/master/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md#sasl-xoauth2-authentication-for-shared-mailboxes-in-office-365).