### PR TITLE
Save refresh token on authorization creation

### DIFF
--- a/inc/application.class.php
+++ b/inc/application.class.php
@@ -431,7 +431,7 @@ JAVASCRIPT;
             $options['prompt'] = 'login';
             break;
          case Google::class:
-            $options['prompt'] = 'select_account';
+            $options['prompt'] = 'consent select_account';
             break;
       }
 

--- a/inc/authorization.class.php
+++ b/inc/authorization.class.php
@@ -411,6 +411,7 @@ class PluginOauthimapAuthorization extends CommonDBChild {
          $application->getForeignKeyField() => $application_id,
          'code'                             => $code,
          'token'                            => json_encode($token->jsonSerialize()),
+         'refresh_token'                    => $token->getRefreshToken(),
          'email'                            => $email,
       ];
 


### PR DESCRIPTION
Since #14, `refresh_token` is stored in a dedicated field. This field was correctly set by migration from previous version, but was not set when a new authorization was created.