### PR TITLE
Fix authorizations cleaning when provider changed

### DIFF
--- a/inc/application.class.php
+++ b/inc/application.class.php
@@ -399,7 +399,7 @@ JAVASCRIPT;
          // Remove codes and tokens if any credentials parameter changed
          $this->deleteChildrenAndRelationsFromDb(
             [
-               PluginOauthimapApplication::class,
+               PluginOauthimapAuthorization::class,
             ]
          );
       }
@@ -567,7 +567,7 @@ JAVASCRIPT;
    function cleanDBonPurge() {
       $this->deleteChildrenAndRelationsFromDb(
          [
-            PluginOauthimapApplication::class,
+            PluginOauthimapAuthorization::class,
          ]
       );
    }


### PR DESCRIPTION
When an application provider was changed, or when the application was deleted, the corresponding authorizations were not cleaned. Indeed, target class was not the good one.

```
[2022-04-01 14:02:01] glpiphplog.WARNING:   *** PHP User Warning (512): Unable to clean elements of class PluginOauthimapApplication as it does not extends "CommonDBConnexity" in /var/www/glpi/src/CommonDBTM.php at line 924
  Backtrace :
  src/CommonDBTM.php:924                             trigger_error()
  plugins/oauthimap/inc/application.class.php:393    CommonDBTM->deleteChildrenAndRelationsFromDb()
  src/CommonDBTM.php:1619                            PluginOauthimapApplication->pre_updateInDB()
  front/dropdown.common.form.php:134                 CommonDBTM->update()
  plugins/oauthimap/front/application.form.php:46    include()
```