### PR TITLE
Add support for `Samesite=Strict` cookie policy

### DIFF
--- a/front/authorization.callback.php
+++ b/front/authorization.callback.php
@@ -28,7 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-
 if (!array_key_exists('cookie_refresh', $_GET)) {
     // Session cookie will not be accessible when user will be redirected from provider website
     // if `session.cookie_samesite` configuration value is `strict`.
@@ -88,9 +87,11 @@ if (is_callable($callback_callable)) {
     call_user_func_array($callback_callable, [$success, $authorization, $callback_params]);
 }
 
-// Redirect to application form if callback action does not exit yet
+// Redirect to application form/list if callback action does not exit yet
 if ($application->getFromDB($application_id)) {
-    Html::redirect($application->getLinkURL());
+    $url = $application->getLinkURL();
+} else {
+    $url = $application->getSearchURL(true);
 }
 
-Html::displayErrorAndDie('lost');
+Html::redirect($url);

--- a/front/authorization.callback.php
+++ b/front/authorization.callback.php
@@ -28,6 +28,26 @@
  * -------------------------------------------------------------------------
  */
 
+
+if (!array_key_exists('cookie_refresh', $_GET)) {
+    // Session cookie will not be accessible when user will be redirected from provider website
+    // if `session.cookie_samesite` configuration value is `strict`.
+    // Redirecting on self using `http-equiv="refresh"` will get around this limitation.
+    $url = htmlspecialchars(
+        $_SERVER['REQUEST_URI'] . (strpos($_SERVER['REQUEST_URI'], '?') !== false ? '&' : '?') . 'cookie_refresh'
+    );
+
+    echo <<<HTML
+<html>
+<head>
+    <meta http-equiv="refresh" content="0;URL='{$url}'"/>
+</head>
+    <body></body>
+</html>
+HTML;
+    exit;
+}
+
 include('../../../inc/includes.php');
 
 $application   = new PluginOauthimapApplication();


### PR DESCRIPTION
When `Samesite=Strict` cookie policy is used, session cookie is not passed when browser is redirected to callback URL. Adding a redirection based on HTML meta tag to reload the page permits to get back session cookie and then reload session used when entering the OAuth authentication process.

Same hack was used for GLPI in https://github.com/glpi-project/glpi/pull/14055.

Fixes !26542