### PR TITLE
Replace deprecated usage of `::set-output`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,7 @@ jobs:
       - name: "Get Composer cache directory"
         id: "composer-cache"
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: "Restore dependencies cache"
         uses: "actions/cache@v3"
         with:


### PR DESCRIPTION
Fixes following deprecation:

![image](https://github.com/pluginsGLPI/oauthimap/assets/33253653/33fd7a8e-071c-4fcd-92d8-55f8efe360ba)
