### PR TITLE
Bugfix: Hide client secret field using password input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Hide the client secret field by rendering it as a password input
+
 ## [1.5.0] - 2025-09-29
 
 ## Fixed

--- a/inc/application.class.php
+++ b/inc/application.class.php
@@ -208,6 +208,7 @@ JAVASCRIPT;
                 echo Html::input(
                     $field_name,
                     [
+                        'type'         => 'password',
                         'autocomplete' => 'off',
                         'value'        => (new GLPIKey())->decrypt($field_value),
                     ],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [Done] I have performed a self-review of my code.
- [Screenshot] I have added tests (when available) that prove my fix is effective or that my feature works.

## Description

- It fixes # (issue number, if applicable) - The Graph API secret was not masked and displayed as plain text
- Here is a brief description of what this PR does - it adds the password type attribute so the field is masked

## Screenshots (if appropriate):
<img width="900" height="208" alt="image" src="https://github.com/user-attachments/assets/335940c7-b04c-4d70-9964-7ea1264cd2dd" />

