### PR TITLE
Fix: expose specific OAuth authorization error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 vendor/
 .gh_token
 *.min.*
+var/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Show the specific OAuth authorization error instead of a generic message
+
 ## [1.5.3] - 2026-06-24
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/front/authorization.process.php
+++ b/front/authorization.process.php
@@ -54,7 +54,11 @@ if (
 } elseif (!array_key_exists('code', $_GET)) {
     Session::addMessageAfterRedirect(__s('Unable to get authorization code', 'oauthimap'), false, ERROR);
 } elseif (!$authorization->createFromCode($application_id, $_GET['code'])) {
-    Session::addMessageAfterRedirect(__s('Unable to save authorization code', 'oauthimap'), false, ERROR);
+    Session::addMessageAfterRedirect(
+        htmlspecialchars($authorization->getLastError() ?? __('Unable to save authorization code', 'oauthimap')),
+        false,
+        ERROR,
+    );
 } else {
     $success = true;
 }

--- a/inc/authorization.class.php
+++ b/inc/authorization.class.php
@@ -31,6 +31,8 @@ use GlpiPlugin\Oauthimap\Imap\ImapOauthProtocol;
 use GlpiPlugin\Oauthimap\Imap\ImapOauthStorage;
 use GlpiPlugin\Oauthimap\MailCollectorFeature;
 use GlpiPlugin\Oauthimap\Oauth\OwnerDetails;
+use GlpiPlugin\Oauthimap\Provider\ProviderInterface;
+use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken;
 
 use function Safe\json_decode;
@@ -53,6 +55,22 @@ class PluginOauthimapAuthorization extends CommonDBChild
      * @var OwnerDetails
      */
     private $owner_details;
+
+    /**
+     * Detail of the last error encountered in createFromCode(), if any.
+     * @var string|null
+     */
+    private $error = null;
+
+    /**
+     * Get detail of the last error encountered in createFromCode().
+     *
+     * @return string|null
+     */
+    public function getLastError(): ?string
+    {
+        return $this->error;
+    }
 
     public static function getTypeName($nb = 0)
     {
@@ -410,19 +428,20 @@ class PluginOauthimapAuthorization extends CommonDBChild
     /**
      * Create an authorization based on authorizarion code.
      *
-     * @param int    $application_id
-     * @param string $code
+     * @param int                                        $application_id
+     * @param string                                     $code
+     * @param (AbstractProvider&ProviderInterface)|null $provider Injected provider, mainly for testing purposes.
      *
      * @return bool
      */
-    public function createFromCode(int $application_id, string $code): bool
+    public function createFromCode(int $application_id, string $code, ?AbstractProvider $provider = null): bool
     {
         $application = new PluginOauthimapApplication();
         if (!$application->getFromDB($application_id)) {
             return false;
         }
 
-        $provider = $application->getProvider();
+        $provider ??= $application->getProvider();
 
         // Get token
         try {
@@ -433,6 +452,8 @@ class PluginOauthimapAuthorization extends CommonDBChild
                 E_USER_WARNING,
             );
 
+            $this->error = sprintf(__('Unable to obtain access token from provider: %s', 'oauthimap'), $e->getMessage());
+
             return false;
         }
 
@@ -442,6 +463,8 @@ class PluginOauthimapAuthorization extends CommonDBChild
         $email               = $this->owner_details->email;
         if ($email === null) {
             trigger_error('Unable to get user email', E_USER_WARNING);
+
+            $this->error = __('The authenticated account does not expose an email address', 'oauthimap');
 
             return false;
         }

--- a/inc/authorization.class.php
+++ b/inc/authorization.class.php
@@ -436,6 +436,7 @@ class PluginOauthimapAuthorization extends CommonDBChild
      */
     public function createFromCode(int $application_id, string $code, ?AbstractProvider $provider = null): bool
     {
+        $this->error = null;
         $application = new PluginOauthimapApplication();
         if (!$application->getFromDB($application_id)) {
             return false;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<phpunit
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    testdox="true"
+    cacheDirectory="var/phpunit"
+>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Units/AuthorizationTest.php
+++ b/tests/Units/AuthorizationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * oauthimap plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of oauthimap plugin.
+ *
+ * This plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this plugin. If not, see <https://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2020-2025 by Teclib'
+ * @license   GPLv3+ https://www.gnu.org/licenses/gpl-3.0.fr.html
+ * @link      https://services.glpi-network.com
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Oauthimap\Tests\Units;
+
+use Glpi\Tests\DbTestCase;
+use GlpiPlugin\Oauthimap\Oauth\OwnerDetails;
+use GlpiPlugin\Oauthimap\Provider\Azure;
+use League\OAuth2\Client\Token\AccessToken;
+use PluginOauthimapApplication;
+use PluginOauthimapAuthorization;
+use RuntimeException;
+
+class AuthorizationTest extends DbTestCase
+{
+    private function createApplication(): PluginOauthimapApplication
+    {
+        return $this->createItem(
+            PluginOauthimapApplication::class,
+            [
+                'name'          => $this->getUniqueString(),
+                'provider'      => Azure::class,
+                'client_id'     => 'fake_client_id',
+                'client_secret' => 'fake_client_secret',
+            ],
+            ['client_secret'],
+        );
+    }
+
+    public function testCreateFromCodeFailsWhenTokenExchangeFails(): void
+    {
+        $application = $this->createApplication();
+
+        $provider = $this->getMockBuilder(Azure::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAccessToken'])
+            ->getMock();
+        $provider->method('getAccessToken')->willThrowException(new RuntimeException('invalid_grant'));
+
+        $authorization = new PluginOauthimapAuthorization();
+        $this->assertFalse($authorization->createFromCode($application->getID(), 'a_code', $provider));
+        $this->assertStringContainsString('invalid_grant', $authorization->getLastError());
+        $this->hasPhpLogRecordThatContains('Error during authorization code fetching: invalid_grant', 'Warning');
+    }
+
+    public function testCreateFromCodeFailsWhenEmailIsMissing(): void
+    {
+        $application = $this->createApplication();
+
+        $owner_details            = new OwnerDetails();
+        $owner_details->email     = null;
+        $owner_details->firstname = 'John';
+        $owner_details->lastname  = 'Doe';
+
+        $provider = $this->getMockBuilder(Azure::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAccessToken', 'getOwnerDetails'])
+            ->getMock();
+        $provider->method('getAccessToken')->willReturn(new AccessToken(['access_token' => 'a_token']));
+        $provider->method('getOwnerDetails')->willReturn($owner_details);
+
+        $authorization = new PluginOauthimapAuthorization();
+        $this->assertFalse($authorization->createFromCode($application->getID(), 'a_code', $provider));
+        $this->assertEquals(
+            'The authenticated account does not expose an email address',
+            $authorization->getLastError(),
+        );
+        $this->hasPhpLogRecordThatContains('Unable to get user email', 'Warning');
+    }
+
+    public function testCreateFromCodeSucceeds(): void
+    {
+        $application = $this->createApplication();
+
+        $owner_details        = new OwnerDetails();
+        $owner_details->email = 'user@example.com';
+
+        $provider = $this->getMockBuilder(Azure::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAccessToken', 'getOwnerDetails'])
+            ->getMock();
+        $provider->method('getAccessToken')->willReturn(
+            new AccessToken(['access_token' => 'a_token', 'refresh_token' => 'a_refresh_token']),
+        );
+        $provider->method('getOwnerDetails')->willReturn($owner_details);
+
+        $authorization = new PluginOauthimapAuthorization();
+        $this->assertTrue($authorization->createFromCode($application->getID(), 'a_code', $provider));
+        $this->assertNull($authorization->getLastError());
+        $this->assertEquals('user@example.com', $authorization->fields['email']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * oauthimap plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of oauthimap plugin.
+ *
+ * This plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this plugin. If not, see <https://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2020-2025 by Teclib'
+ * @license   GPLv3+ https://www.gnu.org/licenses/gpl-3.0.fr.html
+ * @link      https://services.glpi-network.com
+ * -------------------------------------------------------------------------
+ */
+
+$current_plugin_folder = basename(realpath(__DIR__ . '/../'));
+
+require __DIR__ . '/../../../tests/bootstrap.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (!Plugin::isPluginActive($current_plugin_folder)) {
+    throw new RuntimeException("Plugin $current_plugin_folder is not active in the test database");
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44779
- When the IMAP OAuth authorization fails after the provider redirect, GLPI always showed the same generic message "Unable to save authorization code", with no way to tell whether the token exchange failed, the account has no email address, or something else went wrong.
- The authorization process now surfaces the specific failure reason to the user instead of the generic message.

## Screenshots (if appropriate):
