### PR TITLE
Fix: use CFG_GLPI root_doc for dropdownAuthorization AJAX path

### DIFF
--- a/inc/mailcollectorfeature.class.php
+++ b/inc/mailcollectorfeature.class.php
@@ -155,7 +155,7 @@ class MailCollectorFeature extends CommonGLPI
 
                                 application_field.val(application_id);
                                 auth_field_container.load(
-                                    '/plugins/oauthimap/ajax/dropdownAuthorization.php',
+                                    CFG_GLPI['root_doc'] + '/plugins/oauthimap/ajax/dropdownAuthorization.php',
                                     {
                                         application_id: application_id,
                                         selected: login_field.val()


### PR DESCRIPTION
This PR fixes the issue described in #141.

The AJAX call to `dropdownAuthorization.php` used a hardcoded absolute path 
(`/plugins/oauthimap/...`), which breaks on installations where GLPI is not 
at the domain root. This change uses `CFG_GLPI['root_doc']` instead, consistent 
with how paths are handled elsewhere in GLPI core.

Tested on GLPI 11.0.8, installation in a subdirectory (`/glpi/public`).
