### PR TITLE
Fix - Missing include in ajax file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Restore missing include in ajax/dropdownAuthorization.php
+
 ## [1.4.5] - 2026-06-24
 
 ### Fixed

--- a/ajax/dropdownAuthorization.php
+++ b/ajax/dropdownAuthorization.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+include('../../../inc/includes.php');
+
 header('Content-Type: text/html; charset=UTF-8');
 Html::header_nocache();
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45348
- Here is a brief description of what this PR does

593e4960e8784ddecb8de973102ae1ac2974640c removes a required `include(“../../../inc/includes.php”);`, which causes an error in the ‘Login’ field in the collector’s configuration.

## Screenshots (if appropriate):

<img width="1081" height="289" alt="image" src="https://github.com/user-attachments/assets/b9b8ba2b-3263-45ec-bbf0-8282f4a68c2f" />
